### PR TITLE
Fix the logout test to use XPath for username click

### DIFF
--- a/tests/Browser/Auth/AuthenticationTest.php
+++ b/tests/Browser/Auth/AuthenticationTest.php
@@ -50,8 +50,8 @@ test('users can logout', function () {
     actingAs($user);
 
     visit(route('dashboard'))
-        ->click($user->name)
-        ->click('@logout-button')
+        ->click("//*[text()='$user->name']")
+         ->click('@logout-button')
         ->assertUrlIs(route('home'))
         ->assertNoConsoleLogs()
         ->assertNoJavaScriptErrors();


### PR DESCRIPTION
The Logout test is flaky. This MR switches to using the XPath approach to click on the name, which works more reliably.